### PR TITLE
remove empty option in window renaming assist

### DIFF
--- a/assists/n/n.sh
+++ b/assists/n/n.sh
@@ -2,7 +2,7 @@
 
 # assist: rename current window
 
-NEWNAME="$(echo '' | instantmenu -h -1 -p 'rename window' -c -bw 4)"
+NEWNAME="$(echo -n '' | instantmenu -h -1 -p 'rename window' -c -bw 4)"
 [ -z "$NEWNAME" ] && exit
 sleep 0.2
 xdotool getactivewindow set_window --name "$NEWNAME"


### PR DESCRIPTION
without the `-n` echo adds a newline, which makes a empty option when echoing empty quotes