### PR TITLE
assist for custom user assists

### DIFF
--- a/assists/u.sh
+++ b/assists/u.sh
@@ -1,0 +1,28 @@
+#/usr/bin/dash
+
+# assist: custom user assists
+
+USERSCRIPTS="$HOME/.local/share/instantassist/"
+CACHE="$HOME/.cache/instantassist/user_assists"
+
+generate_cache () {
+	for i in "$USERSCRIPTS"*'.sh'; do
+		if [ -x "$i" ]; then
+			echo "processing $i"
+			SUBNAME="$(grep -o '[a-z]\.' <<<"$i" | grep -o '[a-z]')"
+			echo "$SUBNAME$(grep '#'' assist: ' "$i" | sed 's/#'' assist: //')" >> "$CACHE"
+		fi
+	done
+}
+
+[ -d "$USERSCRIPTS" ] || exit
+[ -e "$CACHE" ] || generate_cache
+
+ASSIST="$(instantmenu -i -p instantASSIST -F -ct < "$CACHE" | grep -o '^.')"
+
+[ -z "$ASSIST" ] && exit
+SCRIPTPATH="${USERSCRIPTS}${ASSIST}.sh"
+[ -x "$SCRIPTPATH" ] || exit
+
+"$SCRIPTPATH" &
+iconf lastassist "$SCRIPTPATH"


### PR DESCRIPTION
User assists are stored in `.local/share/instantassist` and the cache is in `.cache/instantassist/user_assists`
They way I handled making the cache means you delete the cache in order to update it after adding/deleting a new assist. The user assists are done in the same way as the system assists, copying a builtin assist to .cache/instantassist will work for testing. All user assists need to be executable in order to go into the cache.