### PR TITLE
read microphone status from pulse device

### DIFF
--- a/assists/v/m.sh
+++ b/assists/v/m.sh
@@ -4,7 +4,7 @@
 
 amixer -D pulse sset Capture toggle
 
-MICSTATUS=$(amixer get Capture | grep -w -o -e "on\|off" | sort -u | tr "[a-z]" "[A-Z]")
+MICSTATUS=$(amixer -D pulse get Capture | grep -w -o -e "on\|off" | sort -u | tr "[a-z]" "[A-Z]")
 
 if [ $MICSTATUS == "OFF" ]; then
     MICICON="/usr/share/icons/Papirus-Dark/symbolic/status/microphone-sensitivity-muted-symbolic.svg"

--- a/assists/v/m.sh
+++ b/assists/v/m.sh
@@ -4,7 +4,10 @@
 
 amixer -D pulse sset Capture toggle
 
+MICSTATUS=$(amixer get Capture | grep -w -o -e "on\|off" | sort -u | tr "[a-z]" "[A-Z]")
+if [ -z "$MICSTATUS" ]; then
 MICSTATUS=$(amixer -D pulse get Capture | grep -w -o -e "on\|off" | sort -u | tr "[a-z]" "[A-Z]")
+fi
 
 if [ $MICSTATUS == "OFF" ]; then
     MICICON="/usr/share/icons/Papirus-Dark/symbolic/status/microphone-sensitivity-muted-symbolic.svg"


### PR DESCRIPTION
Currently MICSTATUS in empty for me without this change. Could be a issue with me using pipewire.