### PR TITLE
search assists function

### DIFF
--- a/cache.sh
+++ b/cache.sh
@@ -4,6 +4,7 @@
 
 rm -rf cache
 mkdir cache
+SEARCH="$(realpath .)/cache/search"
 HELP="$(realpath .)/cache/help"
 CACHE="$(realpath .)/cache/cache"
 CDIR="$(realpath .)/cache"
@@ -26,12 +27,14 @@ for i in ./*; do
             SUBNAME=$(grep -o '[a-z]\.' <<<"$u" | grep -o '[a-z]')
             echo "    $SUBNAME$(grep '# assist: ' "$u" | grep -o ':.*')" >>"$HELP"
             echo "$SUBNAME$(grep '# assist: ' "$u" | sed 's/^# assist: //g')" >>"$CDIR/$CATNAME/cache"
+	    echo "$(grep '# assist: ' "$u" | sed 's/^# assist: //g') ($CATNAME$SUBNAME)" >> "$SEARCH"
         done
         echo "" >>"$HELP"
         cd .. || exit
     else
         SUBNAME=$(grep -o '[a-z]\.' <<<"$i" | grep -o '[a-z]')
         echo "$SUBNAME$(grep '# assist: ' "$i" | grep -o ':.*')" >>"$HELP"
+	echo "$(grep '# assist: ' "$i" | sed 's/^# assist: //g') ($SUBNAME)" >> "$SEARCH"
     fi
 done
 

--- a/instantassist
+++ b/instantassist
@@ -2,9 +2,18 @@
 
 # main menu to access instantASSIST
 
-ASSIST=$(cat /usr/share/instantassist/cache/cache | instantmenu -i -p instantASSIST -F -ct | grep -o '^.')
+ASSIST=$( (cat /usr/share/instantassist/cache/cache; echo /search assists) | instantmenu -i -p instantASSIST -F -ct | grep -o '^.')
 
 [ -z "$ASSIST" ] && exit
+
+if [ "$ASSIST" = '/' ]; then
+    SCRIPTPATH="/usr/share/instantassist/assists/\
+$(cat /usr/share/instantassist/cache/search |
+instantmenu -p 'assist:' -l 8 -i -g 3 -q 'search assists' -h -1 -r |
+sed 's/^.*(//;s/)$//;s/.$/\/&/;s/^\///')"
+    echo $SCRIPTPATH
+    [ -e "$SCRIPTPATH" ] && exit
+else
 
 if [ -d /usr/share/instantassist/assists/"$ASSIST" ]; then
     ASSIST2="$(instantmenu -i -p instantASSIST -n -h 32 -F -ct </usr/share/instantassist/cache/"$ASSIST"/cache | grep -o '^.')"
@@ -17,7 +26,7 @@ else
     fi
     SCRIPTPATH=/usr/share/instantassist/assists/"$ASSIST"
 fi
+fi
 
 "${SCRIPTPATH}.sh" &
 iconf lastassist "${SCRIPTPATH}.sh"
-


### PR DESCRIPTION
Not sure if this should be in the main instantassist script or in an assist. Not using an assist right now because assists can't use / or other symbols, but it feels a little hacky. Using / because its what vim uses for search and s is taken. I think some symbols should be used for more meta assists like this one (maybe . for instantrepeat, ? for help), so maybe a better way of going about this is allowing some symbols in assists (probably only top level ones).