### PR TITLE
fancy tmux attach

### DIFF
--- a/assists/d.sh
+++ b/assists/d.sh
@@ -2,7 +2,7 @@
 
 # assist: attach to tmux session
 
-CHOICE="$(tmux ls | instantmenu -c -bw 4 -q 'search session' -l 40 -w -1 -p 'attach to tmux session')"
+CHOICE="$(tmux ls -F '#{?session_attached,:#{?session_many_attached,y ,b },:r ﴹ} #W [#{b:pane_current_path}] (#{session_windows}) ###{session_name}	#{?session_attached,attached,}' | instantmenu -c -bw 4 -q 'search session' -l 15 -w -1 -p 'attach to tmux session' -h -1 -g 4 -r | sed 's/^.*#//;s/	.*$//')"
 
 [ -z "$CHOICE" ] && exit
 


### PR DESCRIPTION
added some formating for the tmux attach assist

- format is: current window name, [current dir of session], (number of windows in session), #session id, tab for inline instantmenu comments, add attached if attached so you can search for attached sessions

example:
![20210428130139](https://user-images.githubusercontent.com/68208828/116451165-ad64a580-a84b-11eb-8473-b7658b920787.png)
