### PR TITLE
fix brightstep when using light

### DIFF
--- a/utils/b.sh
+++ b/utils/b.sh
@@ -23,6 +23,7 @@ fi
 if iconf -i uselight; then
     USELIGHT=true
     MAXBRIGHT="100"
+    INSTANTOS_BRIGHTSTEP="5"
 fi
 
 syncbright() {


### PR DESCRIPTION
When changing brightness with the `utils/b.sh` script:
if `uselight` is enabled it used the brightstep calculated for the `/sys/class/backlight/...`, which is usually around 50. But `light` has a brightness range from 0 to 100. So when using `light` I hardcoded the brightstep to move 5%.