### PR TITLE
Overwrite existing volume notifications

### DIFF
--- a/utils/p.sh
+++ b/utils/p.sh
@@ -15,7 +15,7 @@ displayvolume() {
     VOLUME="$(pamixer --get-volume || {
         awk -F"[][]" '/Left:/ { print $2 }' <(amixer sget Master) | grep -o '[0-9]*'
     })"
-    dunstify -a instantASSIST -i '/usr/share/icons/Papirus-Dark/symbolic/status/audio-volume-medium-symbolic.svg' -h int:value:"$VOLUME" Volume
+    dunstify -a instantASSIST -i '/usr/share/icons/Papirus-Dark/symbolic/status/audio-volume-medium-symbolic.svg' -h int:value:"$VOLUME" -r 7368551 Volume
 }
 
 case "$1" in


### PR DESCRIPTION
This adds an ID to the notification, thus replacing the old one when send. 7368551 is vaguely "pog" to binary to number

![image](https://user-images.githubusercontent.com/32438954/121920628-86e5c580-cd38-11eb-9cd2-99c87f4e1294.png)
![image](https://user-images.githubusercontent.com/32438954/121920694-92d18780-cd38-11eb-9bbc-25a35ca93ac0.png)
