### PR TITLE
Fix wm switching assist

### DIFF
--- a/assists/t/w.sh
+++ b/assists/t/w.sh
@@ -2,7 +2,10 @@
 
 # assist: switch wm , EXPERIMENTAL
 
-WMSELECT="$(instantmenu -c -l 10 -p 'select window manager' </usr/share/instantassist/menus/data/wm)"
+WMSELECT="$(instantmenu -c -l 10 -p 'select window manager' </usr/share/instantassist/data/wm)"
+
+RTD="$(instantruntimedir)"
+RTD=${RTD:-'/tmp/instantos'}
 
 if [ -z "$WMSELECT" ]; then
     exit
@@ -10,7 +13,7 @@ fi
 
 if command -v "$WMSELECT" &>/dev/null; then
     echo "setting the wm to $WMSELECT"
-    echo "$WMSELECT" >/tmp/wmoverride
+    echo "$WMSELECT" >"$RTD"/wmoverride
     sleep 0.2
     killwm
 else


### PR DESCRIPTION
updates the wm menu dir (menus/data doesn't exist, the wm list is in data)
also updates the assist to use `instantruntimedir` and the same temp dir as startinstantos

needs instantOS/instantOS/pull/116 to be able to switch after the first switch