### PR TITLE
Screenshoting with flameshot doesn't hide instantassist fast enough

### DIFF
--- a/assists/s/a.sh
+++ b/assists/s/a.sh
@@ -3,4 +3,5 @@
 # assist: take screenshot and annotate it using flameshot
 
 instantinstall flameshot && \
+sleep 0.1 && \
 flameshot gui


### PR DESCRIPTION
When using `s + a`, if flameshot is already open, it will start screenshoting before instantassist closes, thus leaving it behind weirdly
![image](https://user-images.githubusercontent.com/32438954/136843598-ce49ac1f-8a53-4337-90ef-db0d1725855d.png)
