### PR TITLE
"r" instantassist: clickable notification after recording is all done processing

### DIFF
--- a/utils/r.sh
+++ b/utils/r.sh
@@ -18,11 +18,10 @@ killrecording() {
 
 finishrecording() {
     ACTION="$(dunstify -A open,"Open filemanager" "recording finished")"
-    SELECTABLE=("nautilus", "nemo") # list of file managers that can take a file as an argument and select it
     FILEMANAGER="$(iconf filemanager)"
 
     if [ "$ACTION" == "open" ]; then
-        if [[ "${SELECTABLE[*]}" =~ "${FILEMANAGER}" ]]; then
+        if [ "$FILEMANAGER" == "nautilus" ]; then
             instantutils open filemanager "$(cat /tmp/recordingname)"
         else
             instantutils open filemanager "$VIDEODIR"


### PR DESCRIPTION
After a video taken from the `r` sections is recorded and processed, a `recording finished` notification will be send.
This notification can be clicked on, and if clicked, it will open the users default file manager with `~/Videos` opened. (and if a file manager supports it, it will select the video as well.. it's targeted at nautilus because that's the default file manager, but in my testing I've found that nemo supports it as well (pcmanfm for some reason doesn't) and couldn't leave it alone)
![image](https://user-images.githubusercontent.com/32438954/138614001-d90aba27-26ec-449a-b602-c05f8c144a48.png)
![image](https://user-images.githubusercontent.com/32438954/138614046-964dd499-3dce-4818-b3e7-64ef465f90fa.png)

